### PR TITLE
Upgrade cryptiles to version 4.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,68 +1,56 @@
 {
-  "name": "npm-lesson-1",
+  "name": "example-manifest",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
-      "requires": {
-        "hoek": "2.x.x"
-      },
+  "packages": {
+    "node_modules/": {
+      "name": "example-manifest",
       "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ=="
-        }
+        "hawk": "9.0.1",
+        "hoek": "6.1.3"
       }
     },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
-      "requires": {
-        "boom": "2.x.x"
-      }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==",
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      },
+    "node_modules/@hapi/b64": {
+      "version": "5.0.0",
       "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ=="
-        }
+        "@hapi/hoek": "9.x.x"
+      },
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz"
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      },
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz"
+    },
+    "node_modules/@hapi/cryptiles": {
+      "version": "5.1.0",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      },
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
-    "hoek": {
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz"
+    },
+    "node_modules/hawk": {
+      "version": "9.0.1",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/cryptiles": "5.x.x"
+      },
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-9.0.1.tgz"
+    },
+    "node_modules/hoek": {
       "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==",
-      "requires": {
-        "hoek": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ=="
-        }
-      }
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-manifest",
   "dependencies": {
-    "hawk": "^3.1.1",
+    "hawk": "9.0.1",
     "hoek": "6.1.3"
   }
 }


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades cryptiles to 4.1.3 to fix vulnerabilities in current version